### PR TITLE
changes aria-owns to aria-controls

### DIFF
--- a/a11y-tabs.js
+++ b/a11y-tabs.js
@@ -60,7 +60,7 @@ function a11yTabs($container, options) {
       'tabIndex': (isSelected) ? 0 : -1, // leveraging jQuery's propFix
       'role': 'tab',
       'aria-selected': isSelected,
-      'aria-owns': $thisPanel.prop('id')
+      'aria-controls': $thisPanel.prop('id')
     });
   });
 

--- a/a11y-tabs.js
+++ b/a11y-tabs.js
@@ -87,7 +87,7 @@ function a11yTabs($container, options) {
     if (e.which === 33) { // PAGE UP
       e.preventDefault();
       // focus the associated tab
-      $('[aria-owns="' + $panel.prop('id') + '"]').focus();
+      $('[aria-controls="' + $panel.prop('id') + '"]').focus();
     }
   });
 
@@ -110,7 +110,7 @@ function a11yTabs($container, options) {
       case 34: // page down
         e.preventDefault();
         // focus the panel
-        $('#' + $tab.attr('aria-owns')).focus();
+        $('#' + $tab.attr('aria-controls')).focus();
     }
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -94,7 +94,7 @@ describe('a11yTabs', function () {
 					}
 					assert($tab.prop('id').length);
 					assert.equal($tab.attr('role'), 'tab');
-					assert.equal($tab.attr('aria-owns'), $panels.eq(i).prop('id'));
+					assert.equal($tab.attr('aria-controls'), $panels.eq(i).prop('id'));
 				});
 			});
 		});


### PR DESCRIPTION
This changes `aria-owns` to `aria-controls` on the tabs themselves. The ARIA Authoring Practices suggest using `aria-controls` to establish the relationship between the tabs and their panels. Furthermore, using `aria-owns` creates a problem I observed using NVDA in Firefox whereby every tab-stop within the panel re-announced "tab selected" - probably because the accessibility tree assumed every item within the panel was also within the tab (per `aria-owns`). This change fixes that issue.